### PR TITLE
Fix Cheatsheet link & use better FontAwesome URL

### DIFF
--- a/index.html
+++ b/index.html
@@ -38,8 +38,8 @@
         <div class="col-sm-12">
           <p class="intro-icons"><i class="wi wi-day-lightning"></i><i class="wi wi-night-thunderstorm"></i><i class="wi wi-day-snow"></i><i class="wi wi-sprinkles"></i><i class="wi wi-day-sunny"></i><i class="wi wi-cloudy"></i><i class="wi wi-night-rain-mix"></i><i class="wi wi-sunset"></i><i class="wi wi-sunrise"></i><i class="wi wi-day-cloudy-windy"></i><i class="wi wi-night-rain"></i><i class="wi wi-night-alt-snow"></i><i class="30bb"></i></p>
           <p class="headline">Weather Icons is a font of 123 weather themed icons, ready to be dropped right into  <a href="http://getbootstrap.com">Bootstrap</a> or any other project.  <i class="wi wi-cloudy"></i></p>
-          <p>Inspired by  <a href="http://fortawesome.github.io/Font-Awesome/"> Font Awesome</a>, they work in essentially the same way. They are infinitley scalable and any CSS that can be applied to text can be applied to them. All you need to do to insert an icon is add the class to an "i" element:   <code>&lt;i class="wi wi-day-lightning"&gt;</code>. At this time, there are no other effects/mixins to do advanced icon manipulation. Those will be coming in future releases. </p>
-          <p>Want to use the font in your desktop applications? Check out the  <a href="/cheatsheet/">cheatsheet here.  </a>Just install the font on your system and copy and paste, it's that easy.</p>
+          <p>Inspired by  <a href="http://fontawesome.io/"> Font Awesome</a>, they work in essentially the same way. They are infinitley scalable and any CSS that can be applied to text can be applied to them. All you need to do to insert an icon is add the class to an "i" element:   <code>&lt;i class="wi wi-day-lightning"&gt;</code>. At this time, there are no other effects/mixins to do advanced icon manipulation. Those will be coming in future releases. </p>
+          <p>Want to use the font in your desktop applications? Check out the  <a href="cheatsheet/">cheatsheet here.  </a>Just install the font on your system and copy and paste, it's that easy.</p>
         </div>
       </div>
     </section>


### PR DESCRIPTION
The cheatsheet link was to `/cheatssheet/` instead of `cheatsheet/`.
