### PR TITLE
Updated bower.json to include one css file in mains array

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -12,7 +12,6 @@
 	"license": "MIT",
 	"main": [
 		"./css/weather-icons.css",
-		"./css/weather-icons.min.css",
 		"./weather-icons/weather-icons.less",
 		"./fonts/*"
 	],


### PR DESCRIPTION
If both css and min.css are in the main array, build tools such as wiredep will add both file to the index.html. 