### PR TITLE
Remove duplicate of wi-owm-803.

### DIFF
--- a/_docs/gh-pages/css/weather-icons.css
+++ b/_docs/gh-pages/css/weather-icons.css
@@ -1404,9 +1404,6 @@
 .wi-owm-803:before {
   content: "\f011";
 }
-.wi-owm-803:before {
-  content: "\f012";
-}
 .wi-owm-804:before {
   content: "\f013";
 }

--- a/_docs/jade/api-list.jade
+++ b/_docs/jade/api-list.jade
@@ -312,8 +312,6 @@ html
           li
             | wi-owm-803: <strong> cloudy-gusts </strong>
           li
-            | wi-owm-803: <strong> cloudy-windy </strong>
-          li
             | wi-owm-804: <strong> cloudy </strong>
           li
             | wi-owm-900: <strong> tornado </strong>


### PR DESCRIPTION
Icon 803 for OpenWeatherMap is duplicated, I double checked, it should correspond `cloudy-gusts`.
Not sure if I made changes into the right place -- is `api-list.html` is autogenerated out of `api-list.jade`?