### PR TITLE
chore(npm): publish under another naming until migration

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,16 +1,11 @@
 {
-  "name": "weather-icons",
-	"version": "2.0.10",
+  "name": "weathericons",
+  "version": "2.0.10",
   "description": "215 weather themed icons inspired by Font Awesome and ready for Bootstrap",
-  "scripts": {},
-  "authors": [
-    "Erik Flowers <erik@helloerik.com>"
-  ],
+  "author": "Erik Flowers <erik@helloerik.com>",
   "license": "MIT",
-  "dependencies": {},
-  "devDependencies": {},
   "homepage": "http://erikflowers.github.io/weather-icons/",
-	"keywords": [
-		"css", "icon-font", "weather", "icon", "icons"
-	]
+  "keywords": [
+    "css", "icon-font", "weather", "icon", "icons"
+  ]
 }


### PR DESCRIPTION
I took the liberty to create the `weathericons` and add you as an owner.
You only have to authenticate with npm and you then can publish anytime you bump the package version.

Closes #97.