### PR TITLE
Update classes-wind-degrees.scss

### DIFF
--- a/sass/icon-classes/classes-wind-degrees.scss
+++ b/sass/icon-classes/classes-wind-degrees.scss
@@ -724,5 +724,5 @@
 }
 
 .wi-wind-towards-n    {
-  @extend .wi-wind.towards-0-deg;
+  @extend .wi-wind, .towards-0-deg;
 }


### PR DESCRIPTION
Module build failed (from ./node_modules/sass-loader/dist/cjs.js):
```
SassError: compound selectors may no longer be extended.
Consider `@extend .wi-wind, .towards-0-deg` instead.
See http://bit.ly/ExtendCompound for details.

    ╷
727 │   @extend .wi-wind.towards-0-deg;
    │           ^^^^^^^^^^^^^^^^^^^^^^
    ╵
  node_modules/weathericons/sass/icon-classes/classes-wind-degrees.scss 727:11  root stylesheet
```